### PR TITLE
Fix duplicate @providesModule conflict / Unable to resolve module AccessibilityInfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 .expo/
 npm-debug.*
+
+.idea/*

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "main": "./src/index.js",
   "keywords":["react-native","react-native-swipe","react-native-swipe-hidden"],
   "dependencies": {
-    "react": "16.0.0-alpha.6",
-    "react-native": "^0.43.4"
   },
   "devDependencies": {
-    "babel-preset-react-native": "1.9.1"
+    "babel-preset-react-native": "1.9.1",
+    "react": "16.0.0-alpha.6",
+    "react-native": "^0.43.4"
   },
   "babel": {
     "env": {


### PR DESCRIPTION
A library should not have react or react-native in its dependencies.
Move them to devDependencies.

See #2 